### PR TITLE
scrollToTop

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -16,7 +16,7 @@ export default function HomePage() {
   const handleScroll = () => {
     if (window.scrollY > 300) {
       setShowButton(true);
-    } else {
+    } else if(window.scrollY===0){
       setShowButton(false);
     }
   };


### PR DESCRIPTION
**Fixes**: #33 
**Description**:
Problem was the scroll to top button was removed out of dom as soon as scrollTop.y reaches  to 300 px and thus terminating scrollTo function.

To solve this issue , I changed the condition to remove scroll Button only after scrolltop.y===0 px.

https://github.com/J0SAL/Decentralized-Expense-Tracker/assets/102049482/16c1d22c-228d-42ce-afc5-a1542396ecbb


This solved the issue.



